### PR TITLE
fix: add checks for old OS versions before installing 'neovim' and 'f…

### DIFF
--- a/src/setup/unix/linux/ubuntu/install-recommend.sh
+++ b/src/setup/unix/linux/ubuntu/install-recommend.sh
@@ -160,19 +160,24 @@ main()
 	${_SUDO} chmod +x /usr/local/bin/yq || exit 2
 	echo "[OK]: Done."
 
-	echo "[INFO]: Installing 'neovim'..."
-	local _arch
-	_arch="${_ARCH_UNAME}"
-	if [ "${_arch}" = "aarch64" ]; then
-		_arch="arm64"
+	if [ "${_IS_OLD_VERSION_OS}" = false ]; then
+		echo "[INFO]: Installing 'neovim'..."
+		local _arch
+		_arch="${_ARCH_UNAME}"
+		if [ "${_arch}" = "aarch64" ]; then
+			_arch="arm64"
+		fi
+		rm -fv "nvim-linux-${_arch}.tar.gz" || exit 2
+		wget "https://github.com/neovim/neovim/releases/latest/download/nvim-linux-${_arch}.tar.gz" || exit 2
+		${_SUDO} rm -rf "/opt/nvim-linux-${_arch}" || exit 2
+		${_SUDO} tar -C /opt -xzf "nvim-linux-${_arch}.tar.gz" || exit 2
+		${_SUDO} ln -sf "/opt/nvim-linux-${_arch}/bin/nvim" /usr/local/bin/nvim || exit 2
+		rm -fv "nvim-linux-${_arch}.tar.gz"
+		echo "[OK]: Done."
+	else
+		echo "[WARN]: OS version is too old to install latest 'neovim', skipping!" >&2
+		echo "[WARN]: If you need to use latest 'neovim', build it from source and install it manually: https://github.com/neovim/neovim" >&2
 	fi
-	rm -fv "nvim-linux-${_arch}.tar.gz" || exit 2
-	wget "https://github.com/neovim/neovim/releases/latest/download/nvim-linux-${_arch}.tar.gz" || exit 2
-	${_SUDO} rm -rf "/opt/nvim-linux-${_arch}" || exit 2
-	${_SUDO} tar -C /opt -xzf "nvim-linux-${_arch}.tar.gz" || exit 2
-	${_SUDO} ln -sf "/opt/nvim-linux-${_arch}/bin/nvim" /usr/local/bin/nvim || exit 2
-	rm -fv "nvim-linux-${_arch}.tar.gz"
-	echo "[OK]: Done."
 
 	echo "[INFO]: Installing 'gh' (GitHub CLI)..."
 	local _tmp_file
@@ -209,7 +214,8 @@ main()
 		rm -fv "fastfetch-linux-${_arch}.deb" || exit 2
 		echo "[OK]: Done."
 	else
-		echo "[WARN]: Skipping 'fastfetch' installation on old version of OS!"
+		echo "[WARN]: OS version is too old to install 'fastfetch', skipping!" >&2
+		echo "[WARN]: If you need to use 'fastfetch', build it from source and install it manually: https://github.com/fastfetch-cli/fastfetch" >&2
 	fi
 
 	if [ "${_ARCH_DPKG}" = "amd64" ]; then


### PR DESCRIPTION
This pull request improves how the installation script for Ubuntu handles older operating system versions by adding clearer messaging and guidance when certain packages cannot be installed automatically. The main changes are focused on user communication and instructions for manual installation of unsupported packages.

Improved handling and messaging for unsupported OS versions:

* Added a warning and guidance for manual installation when the OS version is too old to install the latest `neovim`, including a link to the official build instructions. [[1]](diffhunk://#diff-80e274007bf5d73789e852efda608f5f8fbee318f32e142ecafc96f6beb10c27R163) [[2]](diffhunk://#diff-80e274007bf5d73789e852efda608f5f8fbee318f32e142ecafc96f6beb10c27R177-R180)
* Enhanced the warning for `fastfetch` installation on older OS versions, now including instructions and a link for manual source installation.