### PR TITLE
Reorganize and enhance README setup scripts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repository contains a collection of common useful scripts.
 
 ## 🔨 Scripts
 
-### 🧩 Setup - Ubuntu/Debian
+### Setup - Ubuntu/Debian
 
 | Script | Description | OS | Sudo | Docs |
 |--------|--------------|----|------|------|
@@ -41,21 +41,21 @@ This repository contains a collection of common useful scripts.
 | `setup/unix/linux/ubuntu/install-recommend.sh` | Install recommended extras (lsd, neovim, tailscale...) | Ubuntu/Debian | ✅ | [docs](./docs/setup/unix/linux/ubuntu/install-recommend.md) |
 | `setup/unix/linux/ubuntu/setup-nvidia-container.sh` | Setup NVIDIA drivers & container runtime | Ubuntu/Debian | ✅ | [docs](./docs/setup/unix/linux/ubuntu/setup-nvidia-container.md) |
 
-### 🧩 Setup - Linux
+### Setup - Linux
 
 | Script | Description | OS | Sudo | Docs |
 |--------|--------------|----|------|------|
 | `setup/unix/linux/setup-docker.sh` | Install and configure Docker | Linux | ✅ | [docs](./docs/setup/unix/linux/ubuntu/setup-docker.md) |
 | `setup/unix/linux/setup-user.sh` | Create/configure dev user post-install | Linux | ✅ | [docs](./docs/setup/unix/linux/ubuntu/setup-user.md) |
 
-### 🍏 Setup - macOS
+### Setup - macOS
 
 | Script | Description | OS | Sudo | Docs |
 |--------|--------------|----|------|------|
 | `setup/unix/macos/setup-macos.sh` | Run complete macOS dev setup | macOS | ✅ | [docs](./docs/setup/unix/macos/setup-macos.md) |
 | `setup/unix/macos/install-essentials.sh` | Install Homebrew & core CLI tools | macOS | ✅ | [docs](./docs/setup/unix/macos/install-essentials.md) |
 
-## 🧠 Setup User Environment (per-user)
+### Setup user environment (per-user)
 
 | Script | Description | OS | Sudo | Docs |
 |--------|--------------|----|------|------|
@@ -65,14 +65,14 @@ This repository contains a collection of common useful scripts.
 | `setup/unix/setup-user-dotfiles.sh` | Apply dotfiles/configs | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/setup-user-dotfiles.md) |
 | `setup/unix/setup-user-nvchad.sh` | Install & setup NvChad for Neovim | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/setup-user-nvchad.md) |
 
-## 🧠 Setup Runtimes (per-user)
+### Setup user runtimes (per-user)
 
 | `setup/unix/runtimes/install-user-miniconda.sh` | Install Miniconda and Python | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/install-user-miniconda.md) |
 | `setup/unix/runtimes/install-user-nvm.sh` | Install NVM and Node.js | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/install-user-nvm.md) |
 | `setup/unix/runtimes/install-user-rust.sh` | Install Rust toolchain and runtime | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/install-user-rust.md) |
 | `setup/unix/runtimes/install-user-go.sh` | Install Go runtime | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/install-user-go.md) |
 
-### ⚙️ Account Management (Linux)
+### ⚙️ Account management (Linux)
 
 | Script | Description | OS | Sudo | Docs |
 |--------|--------------|----|------|------|

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,7 @@
----
-title: Home
-hide:
-  - navigation
-#   - toc
----
+# HBAI - Common Scripts
 
-# Home
+[![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](https://choosealicense.com/licenses/mit)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/humblebeeai/script-common?logo=GitHub&color=blue)](https://github.com/humblebeeai/script-common/releases)
 
 This repository contains a collection of common useful scripts.
 
@@ -31,12 +27,70 @@ This repository contains a collection of common useful scripts.
     - **macOS** (support with Homebrew)
     - Other Unix-like systems (limited support)
 
+---
+
+## 🔨 Scripts
+
+### Setup - Ubuntu/Debian
+
+| Script | Description | OS | Sudo | Docs |
+|--------|--------------|----|------|------|
+| `setup/unix/linux/ubuntu/setup-ubuntu.sh` | Run complete Ubuntu setup pipeline | Ubuntu/Debian | ✅ | [docs](./docs/setup/unix/linux/ubuntu/setup-ubuntu.md) |
+| `setup/unix/linux/ubuntu/pre-setup-ubuntu.sh` | Pre-flight setup: update, locale, timezone, hostname, ulimit, umask | Ubuntu/Debian | ✅ | [docs](./docs/setup/unix/linux/ubuntu/pre-setup-ubuntu.md) |
+| `setup/unix/linux/ubuntu/install-essentials.sh` | Install basic build tools & CLI utils | Ubuntu/Debian | ✅ | [docs](./docs/setup/unix/linux/ubuntu/install-essentials.md) |
+| `setup/unix/linux/ubuntu/install-recommend.sh` | Install recommended extras (lsd, neovim, tailscale...) | Ubuntu/Debian | ✅ | [docs](./docs/setup/unix/linux/ubuntu/install-recommend.md) |
+| `setup/unix/linux/ubuntu/setup-nvidia-container.sh` | Setup NVIDIA drivers & container runtime | Ubuntu/Debian | ✅ | [docs](./docs/setup/unix/linux/ubuntu/setup-nvidia-container.md) |
+
+### Setup - Linux
+
+| Script | Description | OS | Sudo | Docs |
+|--------|--------------|----|------|------|
+| `setup/unix/linux/setup-docker.sh` | Install and configure Docker | Linux | ✅ | [docs](./docs/setup/unix/linux/ubuntu/setup-docker.md) |
+| `setup/unix/linux/setup-user.sh` | Create/configure dev user post-install | Linux | ✅ | [docs](./docs/setup/unix/linux/ubuntu/setup-user.md) |
+
+### Setup - macOS
+
+| Script | Description | OS | Sudo | Docs |
+|--------|--------------|----|------|------|
+| `setup/unix/macos/setup-macos.sh` | Run complete macOS dev setup | macOS | ✅ | [docs](./docs/setup/unix/macos/setup-macos.md) |
+| `setup/unix/macos/install-essentials.sh` | Install Homebrew & core CLI tools | macOS | ✅ | [docs](./docs/setup/unix/macos/install-essentials.md) |
+
+### Setup user environment (per-user)
+
+| Script | Description | OS | Sudo | Docs |
+|--------|--------------|----|------|------|
+| `setup/unix/setup-user-env.sh` | Setup user development environment | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/setup-user-env.md) |
+| `setup/unix/setup-user-workspaces.sh` | Create standard workspaces directories | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/setup-user-workspaces.md) |
+| `setup/unix/setup-user-ohmyzsh.sh` | Install Oh My Zsh & plugins | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/setup-user-ohmyzsh.md) |
+| `setup/unix/setup-user-dotfiles.sh` | Apply dotfiles/configs | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/setup-user-dotfiles.md) |
+| `setup/unix/setup-user-nvchad.sh` | Install & setup NvChad for Neovim | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/setup-user-nvchad.md) |
+
+### Setup user runtimes (per-user)
+
+| `setup/unix/runtimes/install-user-miniconda.sh` | Install Miniconda and Python | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/install-user-miniconda.md) |
+| `setup/unix/runtimes/install-user-nvm.sh` | Install NVM and Node.js | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/install-user-nvm.md) |
+| `setup/unix/runtimes/install-user-rust.sh` | Install Rust toolchain and runtime | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/install-user-rust.md) |
+| `setup/unix/runtimes/install-user-go.sh` | Install Go runtime | Unix/Linux/macOS | ❌ | [docs](./docs/runtimes/install-user-go.md) |
+
+### ⚙️ Account management (Linux)
+
+| Script | Description | OS | Sudo | Docs |
+|--------|--------------|----|------|------|
+| `account/unix/linux/create-group.sh` | Create a new system group | Linux | ✅ | [docs](./docs/account/unix/linux/create-group.md) |
+| `account/unix/linux/create-user.sh` | Create a new user with home and shell | Linux | ✅ | [docs](./docs/account/unix/linux/create-user.md) |
+| `account/unix/linux/change-password.sh` | Change a user password non-interactively | Linux | ✅ | [docs](./docs/account/unix/linux/change-password.md) |
+| `account/unix/linux/change-user-pgroup.sh` | Change users' primary group | Linux | ✅ | [docs](./docs/account/unix/linux/change-user-pgroup.md) |
+| `account/unix/linux/add-user-group.sh` | Add existing users to a group | Linux | ✅ | [docs](./docs/account/unix/linux/add-user-group.md) |
+| `account/unix/linux/delete-user.sh` | Delete a user | Linux | ✅ | [docs](./docs/account/unix/linux/delete-user.md) |
+
+---
+
 ## 🚸 Usage/Examples
 
 ### Setup server environment on **Ubuntu (20.04+), Debian (12.0+)**
 
 ```sh
-curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/linux/ubuntu/setup-ubuntu.sh | bash -s -- -u -a
+curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/linux/ubuntu/setup-ubuntu.sh | bash -s -- -u -r all
 ```
 
 Or with other useful options:
@@ -46,7 +100,7 @@ curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/
     --upgrade \
     --hostname=my-server \
     --timezone=Asia/Seoul \
-    --all-runtimes
+    --runtimes=all
 ```
 
 ### Create a new user and setup development environment on most **Linux**
@@ -54,7 +108,7 @@ curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/
 Setup development environment for the current user:
 
 ```sh
-curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/linux/setup-user.sh | bash -s -- -a
+curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/linux/setup-user.sh | bash -s -- -r all
 ```
 
 Create a new user and setup development environment:
@@ -62,7 +116,7 @@ Create a new user and setup development environment:
 ```sh
 curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/linux/setup-user.sh | bash -s -- \
     --user=user \
-    --all-runtimes
+    --runtimes=all
 ```
 
 Create a new user with sudo privileges, password and setup development environment:
@@ -72,7 +126,7 @@ curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/
     --user=admin \
     --password="admin_pass123" \
     --sudo \
-    --all-runtimes
+    --runtimes=all
 ```
 
 ### Setup development environment on **macOS**
@@ -80,7 +134,7 @@ curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/
 Note: This script will install **Homebrew** and any other essential packages if not already installed.
 
 ```sh
-curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/macos/setup-macos.sh | bash -s -- -a
+curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/macos/setup-macos.sh | bash -s -- -r all
 ```
 
 ### Setup development environment on **Unix/Linux/macOS**
@@ -88,5 +142,5 @@ curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/
 Note: This script will only install and setup user-level runtimes and configurations, not system-level packages. Thus it doesn't require root privileges.
 
 ```sh
-curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/setup-user-env.sh | bash -s -- -a
+curl -fsSL https://github.com/humblebeeai/script-common/raw/main/src/setup/unix/setup-user-env.sh | bash -s -- -r all
 ```


### PR DESCRIPTION
This pull request refactors and reorganizes the documentation for the repository's common setup scripts. The main improvements include clearer grouping of setup scripts by operating system and purpose, more consistent naming and locations for scripts, and updated usage examples with standardized argument flags. These changes make it easier for users to find the right setup scripts and understand how to use them across different platforms.

**Documentation and structure improvements:**

* The `README.md` and `docs/README.md` files have been updated to group setup scripts by OS (Ubuntu/Debian, Linux, macOS) and by user/system scope, with new tables and clearer headings for each category. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R75) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R30-R93)
* Script names and locations have been standardized, moving several user environment and runtime scripts under the `setup/unix/` and `setup/unix/runtimes/` directories for consistency. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R75) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R30-R93)
* Usage examples have been updated to use the new `--runtimes=all` flag instead of the previous `--all-runtimes` or `-a`, reflecting changes in script argument handling. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L49-R119) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L75-R145)
* New badges and introductory section have been added to `docs/README.md` for better project visibility and clarity.
* Account management scripts for Linux are now listed in their own section, improving discoverability for administrative tasks.